### PR TITLE
remove numpy version limit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = [
     "wheel",
     "setuptools",
     "cython>=0.21.0",
-    "numpy<v1.20.0",
+    "numpy",
 ]
 
 [tool.pysen]


### PR DESCRIPTION
M1 Macといった新しい環境でビルド出来ないため、バージョン制限を撤廃した。
このことにより起こる弊害を調査しきれていないのでDraft